### PR TITLE
Skip lint and checkov checks during terraform destroy operations (#16)

### DIFF
--- a/.github/workflows/terraform-plan-template.yml
+++ b/.github/workflows/terraform-plan-template.yml
@@ -148,7 +148,7 @@ jobs:
           eval $TF_INIT_CMD
         
       - name: Terraform Lint
-        if: ${{ inputs.enable_static_analysis_checks }}
+        if: ${{ inputs.enable_static_analysis_checks && !inputs.destroy_resources }}
         uses: kewalaka/github-azure-iac-templates/.github/actions/terraform-lint@main
         with:
           root_iac_folder_relative_path: ${{ inputs.root_iac_folder_relative_path }}
@@ -173,7 +173,7 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Terraform security scan with Checkov
-        if: ${{ inputs.enable_checkov }}
+        if: ${{ inputs.enable_checkov && !inputs.destroy_resources }}
         uses: kewalaka/github-azure-iac-templates/.github/actions/checkov-terraform@main
         with:
           root_iac_folder_relative_path: ${{ inputs.root_iac_folder_relative_path }}

--- a/README.md
+++ b/README.md
@@ -179,6 +179,8 @@ The default folder for IaC is `./iac`.  This can be modified using `root_iac_fol
 
 This is enabled by default, can be disabled using `enable_checkov: false`
 
+Security scanning is automatically skipped when performing destroy operations (`destroy_resources: true` or `terraform_action: destroy`).
+
 Check out the actions [README.md](.github/actions/checkov-terraform/README.md) for more details.
 
 ### Infracost (cost estimation)
@@ -204,6 +206,8 @@ Check out the actions [README.md](.github/actions/azure-unlock-firewall/README.m
 ### TFLint, validate and format linting
 
 This is enabled by default, can be disabled using `enable_static_analysis_checks: false`
+
+These checks are automatically skipped when performing destroy operations (`destroy_resources: true` or `terraform_action: destroy`).
 
 TFLint can further be configured in the calling repository by
 placing a file `.tflint.hcl` in the IaC root.


### PR DESCRIPTION
This pull request updates the Terraform workflow and documentation to ensure that static analysis and security checks are not run during destroy operations. This prevents unnecessary or misleading checks when resources are being torn down, and makes the workflow behavior clearer to users.

Workflow logic improvements:

* Updated the conditions in `.github/workflows/terraform-plan-template.yml` so that both the Terraform Lint and Checkov security scan steps are skipped when `destroy_resources` is true, in addition to their existing enablement flags. [[1]](diffhunk://#diff-7e64aaac9eeaf0532fb09e05d687f1da287dac9c461d2e341e7db8fde347c048L151-R151) [[2]](diffhunk://#diff-7e64aaac9eeaf0532fb09e05d687f1da287dac9c461d2e341e7db8fde347c048L176-R176)

Documentation updates:

* Added notes to the `README.md` explaining that security scanning and static analysis checks are automatically skipped during destroy operations (`destroy_resources: true` or `terraform_action: destroy`). [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R182-R183) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R210-R211)